### PR TITLE
Make the instrument format more compliant to SBI

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -552,13 +552,14 @@ void AdlibBlasterAudioProcessor::saveInstrumentToFile(String filename)
 	};
 	FILE* f = fopen(filename.toUTF8(), "wb");
 	if (f) {
-		fwrite("SBI\x1d", 1, 4, f);
+		fwrite("SBI\x1a", 1, 4, f);
 		fwrite("JuceOPLVSTi instrument         \0", 1, 32, f);
 		for (int i = 0; i < 11; i++) {
 			Bit8u regVal = Opl->_ReadReg(sbi_registers[i]);
 			fwrite(&regVal, 1, 1, f);
 		}
-		fwrite("     ", 1, 5, f);
+		char padding[5] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
+		fwrite(padding, 1, 5, f);
 		fclose(f);
 	}
 }


### PR DESCRIPTION
Related to the discussion #74 

>The SBI format should be as described here, the regular SBI format
>http://www.shikadi.net/moddingwiki/SBI_Format

- this changes the header to match the specification
- this sets to zero the undocumented fields which are not detailed in the spec

>byte 11: AdLib drum number
>byte 12: note offset
>byte 13: percussion note number

These extra fields are probably known off some reverse-engineered information, at which I'd love to point you but I'm not able to find right now. I'll search more if you're interested.
OPL3BankEditor handles their case in the SBI parser.

Bisqwit's had a comment about this in his `gen_adldata.cc` from ADLMIDI.
>// [+11] seems to be used also, what is it for?